### PR TITLE
Upgrade to 1.0.3-stable

### DIFF
--- a/filebrowser/values.yaml
+++ b/filebrowser/values.yaml
@@ -1,7 +1,7 @@
 # image: location, and version of the filebrowser-quantum to use
 image:
   repository: ghcr.io/gtsteffaniak/filebrowser
-  tag: 1.0.0-stable
+  tag: 1.0.3-stable
   pullPolicy: IfNotPresent
 
 # securityContext: of the pod
@@ -138,7 +138,7 @@ config:
       noauth: false                         # if set to true, overrides all other auth methods and disables authentication
       password:                             #  validate:omitempty
         enabled: true
-        minLength: 5                        # minimum pasword length required, default is 5.  validate:omitempty
+        minLength: 20                       # minimum pasword length required, default is 5.  validate:omitempty
         signup: false                       # allow signups on login page if enabled -- not secure.  validate:omitempty
         recaptcha:                          # recaptcha config, only used if signup is enabled  validate:omitempty
           host: ""                          #  validate:required
@@ -171,7 +171,7 @@ config:
         url: "https://github.com/Softwaredam/filebrowser-chart/"
       - text: "Release sources"                 # the text to display on the link  validate:required
         title: "Release sources"                  # the title to display on hover
-        url: "https://github.com/gtsteffaniak/filebrowser/tree/stable/v1.0.0" # the url to link to  validate:required
+        url: "https://github.com/gtsteffaniak/filebrowser/releases/" # the url to link to  validate:required
     disableNavButtons: false                # disable the nav buttons in the sidebar
     styling:
       disableEventThemes: false             # disable the event based themes,


### PR DESCRIPTION
Changes:
- Upgrade to 1.0.3-stable (no backward compatibility problems seen during smoke testing)
- Keep pass lengths consistent