### PR TITLE
feat(secrets): load env vars from secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,26 @@ ingress:
 
 adminPassword:
   passwordLength: 50
-  passwordOverride: ""  # Leave empty to auto-generate
+  createSecret: true   # Set false if providing FILEBROWSER_ADMIN_PASSWORD via existingSecrets
+
+existingSecrets:
+  - name: filebrowser-secrets
 ```
+
+Create a Kubernetes secret with environment variables to override config values:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: filebrowser-secrets
+type: Opaque
+stringData:
+  FILEBROWSER_ADMIN_PASSWORD: "your-admin-secret"
+  FILEBROWSER_JWT_TOKEN_SECRET: "your-jwt-secret"
+```
+
+See the [FileBrowser documentation](https://filebrowserquantum.com/en/docs/reference/environment-variables/) for all available environment variables and secrets.
 
 ## Deployment
 
@@ -62,8 +80,12 @@ helm upgrade --install \
 ```
 
 ### Admin password
-After each upgrade/deploy, a new secret will be generated if not provided through config. 
-To get the password, use the following for ease: 
+Two ways to set the admin password:
+
+1. **Auto-generate** (default): `createSecret: true`
+2. **External secret**: `createSecret: false`, include `FILEBROWSER_ADMIN_PASSWORD` in your secret
+
+To retrieve an auto-generated password:
 
 ```bash
 export FILEBROWSER_NAMESPACE="filebrowser"

--- a/filebrowser/templates/deployment.yaml
+++ b/filebrowser/templates/deployment.yaml
@@ -38,17 +38,17 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: 8080
-          env: 
-            - name: FILEBROWSER_CONFIG 
+          env:
+            - name: FILEBROWSER_CONFIG
               value: /home/filebrowser/config.yaml
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           envFrom:
-            {{- if .Values.adminPassword.createSecret }}
             - secretRef:
                 name: {{ .Release.Name }}-filebrowser-quantum
-            {{- end }}
-            {{- range .Values.existingSecrets }}
-            - secretRef:
-                name: {{ .name }}
+            {{- with .Values.extraEnvFromSecrets }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             requests:
@@ -71,7 +71,7 @@ spec:
               mountPath: /home/filebrowser/config.yaml
               subPath: config.yaml
             - name: config-volume
-              mountPath: /home/filebrowser/data          
+              mountPath: /home/filebrowser/data
             {{- if .Values.persistence.enabled }}
             - name: data-volume
               mountPath: /data
@@ -85,7 +85,7 @@ spec:
             name: {{ .Release.Name }}-filebrowser-quantum
         - name: config-volume
           persistentVolumeClaim:
-            claimName: {{ .Release.Name }}-filebrowser-quantum-config       
+            claimName: {{ .Release.Name }}-filebrowser-quantum-config
         {{- if .Values.persistence.enabled }}
         - name: data-volume
           persistentVolumeClaim:

--- a/filebrowser/templates/deployment.yaml
+++ b/filebrowser/templates/deployment.yaml
@@ -42,8 +42,14 @@ spec:
             - name: FILEBROWSER_CONFIG 
               value: /home/filebrowser/config.yaml
           envFrom:
+            {{- if .Values.adminPassword.createSecret }}
             - secretRef:
                 name: {{ .Release.Name }}-filebrowser-quantum
+            {{- end }}
+            {{- range .Values.existingSecrets }}
+            - secretRef:
+                name: {{ .name }}
+            {{- end }}
           resources:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}

--- a/filebrowser/templates/pvcs.yaml
+++ b/filebrowser/templates/pvcs.yaml
@@ -3,38 +3,44 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if .Values.persistence.keep }}
   annotations:
+    {{- if .Values.persistence.keep }}
     helm.sh/resource-policy: keep
-  {{- end }}
+    {{- end }}
+    {{- with .Values.persistence.data.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ .Release.Name }}-filebrowser-quantum-data
   labels:
     release: {{ .Release.Name }}
     app: filebrowser-quantum
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ .Values.persistence.data.accessMode | default .Values.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.persistence.dataSize }}
-  storageClassName: {{ .Values.persistence.storageClass }}
-{{- end }}
+      storage: {{ .Values.persistence.data.size }}
+  storageClassName: {{ .Values.persistence.data.storageClass | default .Values.persistence.storageClass }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if .Values.persistence.keep }}
   annotations:
+    {{- if .Values.persistence.keep }}
     helm.sh/resource-policy: keep
-  {{- end }}
+    {{- end }}
+    {{- with .Values.persistence.config.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ .Release.Name }}-filebrowser-quantum-config
   labels:
     release: {{ .Release.Name }}
     app: filebrowser-quantum
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ .Values.persistence.config.accessMode | default .Values.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.persistence.configSize }}
-  storageClassName: {{ .Values.persistence.storageClass }}
+      storage: {{ .Values.persistence.config.size }}
+  storageClassName: {{ .Values.persistence.config.storageClass | default .Values.persistence.storageClass }}
+{{- end }}

--- a/filebrowser/templates/secret.yaml
+++ b/filebrowser/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.adminPassword.createSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -8,10 +9,7 @@ metadata:
     app: filebrowser-quantum
 type: Opaque
 stringData:
-  FILEBROWSER_ADMIN_PASSWORD: {{- if .Values.adminPassword.passwordOverride }}
-    {{ .Values.adminPassword.passwordOverride }}
-  {{- else }}
-    {{- $length := int (.Values.adminPassword.passwordLength | default 20) }}
+  FILEBROWSER_ADMIN_PASSWORD: {{- $length := int (.Values.adminPassword.passwordLength | default 20) }}
     {{- $chars := splitList "" "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#%^-" }}
     {{- $charCount := len $chars }}
     {{- $password := "" }}
@@ -20,4 +18,4 @@ stringData:
       {{- $password = printf "%s%s" $password (index $chars $index) }}
     {{- end }}
     {{ $password }}
-  {{- end }}
+{{- end }}

--- a/filebrowser/values.yaml
+++ b/filebrowser/values.yaml
@@ -64,6 +64,28 @@ extraVolumes: []
 #     readOnly: false
 extraVolumeMounts: []
 
+# extraEnv: Add individual environment variables referencing existing secrets
+# Example:
+# extraEnv:
+#   - name: FILEBROWSER_JWT_KEY
+#     valueFrom:
+#       secretKeyRef:
+#         name: filebrowser-jwt-secret
+#         key: jwt-token
+#   - name: ONLYOFFICE_JWT_SECRET
+#     valueFrom:
+#       secretKeyRef:
+#         name: onlyoffice-secret
+#         key: jwt-secret
+extraEnv: []
+
+# extraEnvFromSecrets: Load entire secrets as environment variables
+# Example:
+# extraEnvFromSecrets:
+#   - secretRef:
+#       name: my-existing-secret
+extraEnvFromSecrets: []
+
 #adminPassword: config for FILEBROWSER_ADMIN_PASSWORD env var.
 adminPassword:
   #passwordLength: for auto-generated password. Also set the minLength under config

--- a/filebrowser/values.yaml
+++ b/filebrowser/values.yaml
@@ -64,11 +64,19 @@ extraVolumes: []
 #     readOnly: false
 extraVolumeMounts: []
 
-#adminPassword: overrides the FILEBROWSER_ADMIN_PASSWORD env var. 
+#adminPassword: config for FILEBROWSER_ADMIN_PASSWORD env var.
 adminPassword:
-  #passwordLength: for admin. Also set the minLength under config
+  #passwordLength: for auto-generated password. Also set the minLength under config
   passwordLength: 20
-  passwordOverride: ""  # Leave empty to auto-generate
+  #createSecret: set to false when providing FILEBROWSER_ADMIN_PASSWORD via existingSecrets
+  createSecret: true
+
+# existingSecrets: List of existing Kubernetes secrets to load as environment variables.
+existingSecrets: []
+# Example:
+# existingSecrets:
+#   - name: my-filebrowser-secrets
+#   - name: my-jwt-secrets
 
 #config: contains application config file which will be mounted to the pod
 #config: these defaults are copied from https://github.com/gtsteffaniak/filebrowser/blob/stable/v1.0.0/frontend/public/config.generated.yaml


### PR DESCRIPTION
> IN PROGRESS

# TODO
- cannot log in when password is loaded via env var https://github.com/gtsteffaniak/filebrowser/issues/2317
- ensure that JWT token for OnlyOffice (and others) is passed correctly to config
```yaml
 office:
    internalUrl: ""
    secret: ""
```

Resolves https://github.com/Softwaredam/filebrowser-chart/issues/23

# Description

- Add option to load specific env variables (that contain secrets) from `existingSecret`.
- I removed the option to supplement the `passwordOverride` in plain text.

## Example usage
```yaml
# Auto-generate (default):
adminPassword:
  createSecret: true

# External secret only:
adminPassword:
  createSecret: false

  existingSecrets:
    - name: my-secrets 
```

## Testing

- ✅  `helm lint filebrowser/`
- ✅  `helm template fb-test filebrowser/`
- ✅  `helm install fb-test filebrowser/ --dry-run --debug`
- Cleanup `helm uninstall fb-test -n filebrowser-v2` and `k delete ns filebrowser-v2`


### ✅ Create admin password by default 

```bash
k create ns filebrowser-v2

# in values
# adminPassword:
#   passwordLength: 20
#   createSecret: true
#
#  existingSecrets: []

helm install fb-test filebrowser/ -n filebrowser-v2
```
- secret is created
<img width="1011" height="87" alt="image" src="https://github.com/user-attachments/assets/fb8e45ee-78ef-4667-a06b-eca5a686dcff" />
<img width="387" height="71" alt="image" src="https://github.com/user-attachments/assets/86e1b713-6290-4c44-8105-682f452987fb" />

- Logging in works.

### 🛑  Supplement password through external secret
```bash
k create ns filebrowser-v2

k create secret generic filebrowser-secrets \
    --from-literal=FILEBROWSER_ADMIN_PASSWORD="your-admin-secret" \
    --from-literal=FILEBROWSER_JWT_TOKEN_SECRET="your-jwt-secret" \
    --namespace=filebrowser-v2

# in values
# adminPassword:
#   createSecret: false  # Disable auto-generated secret
#
#  existingSecrets:
#    - name: filebrowser-secrets

# install
helm install fb-test filebrowser/ -n filebrowser-v2
```
- secret is created 
<img width="920" height="55" alt="image" src="https://github.com/user-attachments/assets/84853e60-eb35-42d5-ab7d-6656de31f243" />
<img width="360" height="72" alt="image" src="https://github.com/user-attachments/assets/0904a7cc-f3e1-4dba-a99b-842507590175" />

- I see env vars in logs

```
 2026/04/19 15:19:59 [DEBUG] Default SQLite driver initialized                                                                                                                                                                                                                                                                                                            │
│ 2026/04/19 15:19:59 [INFO ] Using admin password from FILEBROWSER_ADMIN_PASSWORD environment variable                                                                                                                                                                                                                                                                    │
│ 2026/04/19 15:19:59 [INFO ] Using JWT Token Secret from FILEBROWSER_JWT_TOKEN_SECRET environment variable                                                                                                                                                                                                                                                                │
│ 2026/04/19 15:19:59 [INFO ] cache directory setup successfully: tmp                                                                                                                                                                                                                                                                                                      │
│ 2026/04/19 15:19:59 [INFO ] Initializing FileBrowser Quantum (v1.2.4-stable)                                                                                                                                                                                                                                                                                             │
│ 2026/04/19 15:19:59 [INFO ] Using Config file        : /home/filebrowser/config.yaml                                                                                                                                                                                                                                                                                     │
│ 2026/04/19 15:19:59 [INFO ] Auth Methods             : [password]                                                                                                                                                                                                                                                                                                        │
│ 2026/04/19 15:19:59 [INFO ] Using existing database  : /home/filebrowser/data/database.db                                                                                                                                                                                                                                                                                │
│ 2026/04/19 15:19:59 [INFO ] Sources                  : [Data: /data]                                                                                                                                                                                                                                                                                                     │
│ 2026/04/19 15:19:59 [INFO ] SQL Journal Mode         : OFF                                                                                                                                                                                                                                                                                                               │
│ 2026/04/19 15:19:59 [INFO ] initializing index: [Data]                                                                                                                                                                                                                                                                                                                   │
│ 2026/04/19 15:19:59 [INFO ] Generating PWA icons...                                                                                                                                                                                                                                                                                                                      │
│ 2026/04/19 15:19:59 [INFO ] Running at               : http://0.0.0.0:8080/                                                                                                                                                                                                                                                                                              │
│ 2026/04/19 15:20:10 GET     | 200 | 10.244.6.1:44674 | N/A          | 0ms          | "/health"  
```
- 🔴 Logging in DOES NOT works.


