### PR TITLE
feat(workflows): release workflow

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,65 @@
+# .github/workflows/helm-release.yml
+name: Release Helm Chart
+
+on:
+  push:
+    tags:
+      - 'filebrowser-quantum-v*'   # only triggers on tags like filebrowser-quantum-v1.2.3
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for git-cliff changelog range
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          # strips "filebrowser-quantum-v" prefix → "1.2.3"
+          VERSION=${GITHUB_REF_NAME#filebrowser-quantum-v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint chart
+        run: helm lint filebrowser
+
+      - name: Generate changelog
+        id: changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          args: --latest --strip header
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Update Chart.yaml version
+        run: |
+          sed -i "s/^version:.*/version: ${{ steps.version.outputs.version }}/" filebrowser/Chart.yaml
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            -u ${{ github.actor }} --password-stdin
+
+      - name: Package and push chart
+        run: |
+          helm package filebrowser --version ${{ steps.version.outputs.version }}
+          helm push filebrowser-quantum-${{ steps.version.outputs.version }}.tgz \
+            oci://ghcr.io/${{ github.repository_owner }}/helm-charts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "filebrowser-quantum v${{ steps.version.outputs.version }}"
+          body: ${{ steps.changelog.outputs.content }}
+          files: filebrowser-quantum-${{ steps.version.outputs.version }}.tgz

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ If you require commercial support, consulting, or custom solutions, please feel 
 - Sufficent resources
 - Helm3
 
+## Quick Start
+
+Install the chart directly from the GitHub Container Registry (OCI):
+
+```bash
+helm upgrade --install filebrowser \
+  oci://ghcr.io/softwaredam/helm-charts/filebrowser-quantum \
+  --namespace filebrowser \
+  --create-namespace \
+  --values filebrowser-values.yaml
+```
+
 ## Configuration
 
 This chart supports multiple ways to prepare your deployment configuration. See `values.yaml` for all the possibilities. 
@@ -34,12 +46,9 @@ Filebrowser Quantum requires a `config.yaml` for application configuration. This
 ### Admin password
 After each upgrade/deploy, a new password will be generated for the admin user. This is intentional to keep the admin password rolling. the default admin password can be overridden (not recommended) through config. 
 
-To get the password, use the following for ease:
+To get the password, use the following:
 ```bash
-export FILEBROWSER_NAMESPACE="filebrowser"
-export RELEASE_NAME="share"
-
-kubectl -n "${FILEBROWSER_NAMESPACE}"  get secrets ${RELEASE_NAME}-filebrowser-quantum -oyaml | yq '.data.FILEBROWSER_ADMIN_PASSWORD' | base64 -d | pbcopy
+kubectl -n filebrowser get secrets filebrowser-filebrowser-quantum -oyaml | yq '.data.FILEBROWSER_ADMIN_PASSWORD' | base64 -d | pbcopy
 ```
 
 ### Other secrets
@@ -111,23 +120,6 @@ adminPassword:
 extraEnvSecrets:
     FILEBROWSER_OIDC_CLIENT_ID: the-oidc-client-id
     FILEBROWSER_OIDC_CLIENT_SECRET: the-oidc-client-secret
-```
-
-## Deployment
-
-Use `helm` to install, like:
-
-```bash
-export FILEBROWSER_NAMESPACE="filebrowser"
-export RELEASE_NAME="share"
-
-helm upgrade --install \
-     --namespace="${FILEBROWSER_NAMESPACE}" \
-     --create-namespace \
-     "${RELEASE_NAME}" \
-     filebrowser \
-     --values filebrowser-values.yaml \
-     --values decrypted-sops-secrets.yaml
 ```
 
 ## Kubernetes objects


### PR DESCRIPTION
# Description

- Workflow that releases chart to OCI and adjusted `README.md`.
- I added a simple linter, it might be worth to add more like `yamllint` (especially), `kubeconform`, `chart-testing`
- The release process would be:
```bash
git commit -m "add resource limit values"

git push

git tag my-chart-v1.3.0
git push origin my-chart-v1.3.0

# workflow runs, pushes to OCI, creates a release
```
- Something to think about
  - If we enforce conventional commits, we can have nice release notes with `cliff.toml`.
  - The tag needs to be pushed manually, but that not that bad.
  - Would be nice to add docs for contributors.
  - Would be nice to add pre-commit with the same linters and checks the release workflow would have.
- Not fully tested just yet, but I wanted to push it to have a discussion