### PR TITLE
Upgrade to 1.4.0-stable

### DIFF
--- a/filebrowser/values.yaml
+++ b/filebrowser/values.yaml
@@ -1,7 +1,7 @@
 # image: location, and version of the filebrowser-quantum to use
 image:
   repository: ghcr.io/gtsteffaniak/filebrowser
-  tag: 1.3.3-stable
+  tag: 1.4.0-stable
   pullPolicy: IfNotPresent
 
 # securityContext: of the pod
@@ -116,8 +116,8 @@ config:
   server:
     minSearchLength: 3                      # minimum length of search query to begin searching (default: 3)
     disableUpdateCheck: false               # disables backend update check service
-    numImageProcessors: 4                   # number of concurrent image processing jobs used to create previews, default is number of cpu cores available.
-    socket: ""                              # socket to listen on
+    numImageProcessors: 4                   # number of concurrent image processing jobs used to create previews, default is 4.
+    socket: ""                              # socket to listen on - eg. /var/run/filebrowser.sock
     tlsKey: ""                              # path to TLS key
     tlsCert: ""                             # path to TLS cert
     disablePreviews: false                  # disable all previews thumbnails, simple icons will be used
@@ -133,6 +133,7 @@ config:
         noColors: false                     # disable colors in the output
         json: false                         # output in json format
         utc: false                          # use UTC time in the output instead of local time
+        apiFilter: ""                       # regex filter that excludes matching full api paths from being logged. (eg. '/user\?id\=self') Defaults to '^/health|^/favicon.ico|^/static|^/public/static'
     database: /home/filebrowser/data/database.db  # path to the database file. Default under data PVC to persist
     sources:                                #  validate:required,dive
       - path: /data                         # file system path. (Can be relative)  validate:required
@@ -140,6 +141,7 @@ config:
         config:
           denyByDefault: false              # deny access unless an "allow" access rule was specifically created.
           private: false                    # designate as source as private -- currently just means no sharing permitted.
+          readOnly: false                   # read-only source, changes from the UI, webdav, and API will be disabled.
           disabled: false                   # disable the source, this is useful so you don't need to remove it from the config file
           rules:                            # list of item rules to apply to specific paths
             - neverWatchPath: ""            # index the folder in the first pass to get included in search, but never re-indexed.
@@ -231,8 +233,14 @@ config:
         disableVerifyTLS: false             # disable TLS verification (insecure, for testing only)
         logoutRedirectUrl: ""               # if provider logout url is provided, filebrowser will also redirect to logout url. Custom logout query params are respected.
         header: ""                          # HTTP header to look for JWT token (e.g. X-JWT-Assertion). Default is "X-JWT-Assertion"
-        secret: ""                          # Shared secret key/bytes for verifying JWT token signatures (required, eg PUBLIC KEY, RSA PUBLIC KEY, EC PUBLIC KEY, or CERTIFICATE)
+        secret: ""                          # secret: Shared secret key/bytes for verifying JWT token signatures (required, eg PUBLIC KEY, RSA PUBLIC KEY, EC PUBLIC KEY, or CERTIFICATE)
         algorithm: ""                       # JWT signing algorithm (HS256, HS384, HS512, RS256, ES256). Default is "HS256"
+      passkey:                              #  validate:omitempty
+        enabled: false                      # whether to enable passkey MFA
+        rpDisplayName: ""                   # the Relying Party display name (defaults to frontend name)
+        rpId: ""                            # the Relying Party ID; if empty, auto-derived from base URL host
+        rpOrigins:                          # allowed origins; if empty, auto-derived from base URL
+        loginButtonText: ""                 # custom text for the passkey login button
     key: ""                                 # secret: the key used to sign the JWT tokens. If not set, a random key will be generated.
     adminUsername: "admin"                       # secret: the username of the admin user. If not set, the default is "admin".
     adminPassword: "**hidden**"             # secret: the password of the admin user. If not set, the default is "admin".
@@ -267,60 +275,70 @@ config:
     loginButtonText: ""                     # text to display on the login button
     oidcLoginButtonText: ""                 # text to display on the OIDC login button
   userDefaults:
-    editorQuickSave: false                  # show quick save button in editor
-    hideSidebarFileActions: false           # hide the file actions in the sidebar
-    disableQuickToggles: false              # disable the quick toggles in the sidebar
-    disableSearchOptions: false             # disable the search options in the search bar
-    stickySidebar: true                     # keep sidebar open when navigating
-    hideFilesInTree: false                  # hide files in the sidebar tree navigation, when true, will show only directories.
-    darkMode: true                          # should dark mode be enabled
-    locale: "en"                            # language to use: eg. de, en, or fr
-    viewMode: "normal"                      # view mode to use: eg. normal, list, grid, or compact
-    singleClick: false                      # open directory on single click, also enables middle click to open in new tab
-    showHidden: false                       # show hidden files in the UI. On windows this includes files starting with a dot and windows hidden files
-    dateFormat: false                       # when false, the date is relative, when true, the date is an exact timestamp
-    gallerySize: 3                          # 0-9 - the size of the gallery thumbnails
-    themeColor: "var(--blue)"               # theme color to use: eg. #ff0000, or var(--red), var(--purple), etc
-    quickDownload: false                    # show icon to download in one click
-    disablePreviewExt: ""                   # space separated list of file extensions to disable preview for
-    disableViewingExt: ""                   # space separated list of file extensions to disable viewing for
-    lockPassword: false                     # disable the user from changing their password
-    disableSettings: false                  # disable the user from viewing the settings page
+    sidebar:                                # New organized structure
+      disableQuickToggles: false            # disable the quick toggles in the sidebar
+      hideFileActions: false                # hide the file actions in the sidebar
+      disableHideOnPreview: false           # keep sidebar open when previewing files (was preview.disableHideSidebar)
+      sticky: true                          # keep sidebar open when navigating
+      hideFiles: false                      # hide files in the sidebar tree navigation, when true, will show only directories
+      showTools: true                       # show sidebar links with category "tool"; default is true
+    listing:
+      deleteWithoutConfirming: false        # delete files without confirmation
+      dateFormat: false                     # when false, the date is relative, when true, the date is an exact timestamp
+      showHidden: false                     # show hidden files in the UI. On windows this includes files starting with a dot and windows hidden files
+      quickDownload: false                  # show icon to download in one click
+      showSelectMultiple: false             # show select multiple files on desktop
+      singleClick: false                    # open directory on single click, also enables middle click to open in new tab
+      hideFileExt: ""                       # space separated list of file extensions to hide in UI
+      showCopyPath: false                   # show copy path button in the context menu
+      deleteAfterArchive: true              # delete source files after successful creation/extraction of archives
+      viewMode: "normal"                    # view mode to use: eg. normal, list, grid, or compact
+      gallerySize: 3                        # 0-9 - the size of the gallery thumbnails
     preview:
-      disableHideSidebar: false             # keep sidebar open when previewing files
       image: true                           # show thumbnails for image files
       video: true                           # show thumbnails for video files
       audio: true                           # show thumbnails for audio files
       motionVideoPreview: true              # show multiple frames for videos in thumbnail preview when hovering
       office: true                          # show thumbnails for office files
       popup: true                           # show larger popup preview when hovering over thumbnail
-      autoplayMedia: true                   # autoplay media files in preview
-      defaultMediaPlayer: false             # disable the styled feature-rich media player for browser default
+      disablePreviewExt: ""                 # comma separated list of file extensions to disable preview for
+      highQuality: true                     # high quality preview thumbnails
       folder: true                          # show thumbnails for folders that have previewable contents
       models: true                          # show live thumbnails for 3D models files
-    permissions:
-      api: false                            # allow api access
-      admin: false                          # allow admin access
-      modify: false                         # allow modifying files
-      share: false                          # allow sharing files
-      realtime: false                       # allow realtime updates
-      delete: false                         # allow deleting files
-      create: false                         # allow creating or uploading files
-      download: true                        # allow downloading files
-    loginMethod: "password"                 # login method to use: eg. password, proxy, oidc
-    disableUpdateNotifications: false       # disable update notifications banner for admin users
-    deleteWithoutConfirming: false          # delete files without confirmation
-    deleteAfterArchive: true                # delete source files after successful creation/extraction of archives
-    fileLoading:                            # upload and download settings
+    fileViewer:
+      editorQuickSave: false                # show quick save button in editor
+      autoplayMedia: true                   # autoplay media files in preview
+      disableViewingExt: ""                 # comma separated list of file extensions to disable viewing for
+      disableOnlyOfficeExt: ".md .txt .pdf .html .xml" # list of file extensions to disable onlyoffice editor for
+      preferEditorForMarkdown: false        # prefer editor first for markdown files instead of the Markdown Viewer
+      debugOffice: false                    # debug onlyoffice editor
+      defaultMediaPlayer: false             # disable the styled feature-rich media player for browser default
+    search:
+      disableOptions: false                 # disable the search options in the search bar
+    ui:
+      darkMode: true                        # should dark mode be enabled
+      themeColor: "var(--blue)"             # theme color to use: eg. #ff0000, or var(--red), var(--purple), etc
+      customTheme: ""                       # Name of theme to use chosen from custom themes config
+      locale: "en"                          # language to use: eg. de, en, or fr
+    fileLoading:
       maxConcurrentUpload: 10
       uploadChunkSizeMb: 10
       clearAll: false
       downloadChunkSizeMb: 0
-    disableOnlyOfficeExt: ".md .txt .pdf .html .xml" # list of file extensions to disable onlyoffice editor for
-    customTheme: ""                         # Name of theme to use chosen from custom themes config.
-    showSelectMultiple: false               # show select multiple files on desktop
-    debugOffice: false                      # debug onlyoffice editor
-    preferEditorForMarkdown: false          # prefer editor first for markdown files instead of the Markdown Viewer.
+    account:
+      permissions:
+        api: false                          # allow api access
+        admin: false                        # allow admin access
+        modify: false                       # allow modifying files
+        share: false                        # allow sharing files
+        realtime: false                     # allow realtime updates
+        delete: false                       # allow deleting files
+        create: false                       # allow creating or uploading files
+        download: true                      # allow downloading files
+      lockPassword: false                   # disable the user from changing their password
+      disableSettings: false                # disable the user from viewing the settings page
+      loginMethod: "password"               # login method to use: eg. password, proxy, oidc
+      disableUpdateNotifications: false     # disable update notifications banner for admin users
   integrations:
     office:                                 #  validate:omitempty
       url: ""                               # The URL to the OnlyOffice Document Server, needs to be accessible to the user.  validate:required
@@ -355,3 +373,6 @@ config:
       debug: false                          # output ffmpeg stdout for media integration -- careful can produces lots of output!
       extractEmbeddedSubtitles: false       # extract embedded subtitles from media files
       exiftoolPath: ""                      # path to exiftool executable
+  http:
+    trustedHeaders:                         # list of headers to trust, useful when behind a reverse proxy.
+    disableRateLimit: false                 # turns off built-in auth route rate limiting and failed-login lockout (default false).


### PR DESCRIPTION
Upgrade tested. The deprecated share config `disableIndexing` did cause trouble in the overloaded config. It is removed now.